### PR TITLE
fixing possible typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,8 +115,8 @@
 				<a href="https://github.com/melroser">
 					GitHub
 				</a> | 				
-                <a href="https://linkdin.com/in/themelroser">
-					LinkdIn
+                <a href="https://linkedin.com/in/themelroser">
+					LinkedIn
 				</a> | 
 				<a href="https://registry.jsonresume.com/melroser">
 					Resume


### PR DESCRIPTION
i noticed that linkedin was spelled linkdin i think it might be a typo because linkdin.com does exist but it just shows a 404 error when visited